### PR TITLE
Fix Console integration

### DIFF
--- a/src/Command/BenchmarkCommand.php
+++ b/src/Command/BenchmarkCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Drupal\AppConsole\Command\ContainerAwareCommand;
+use Drupal\Console\Command\ContainerAwareCommand;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Yaml\Yaml;

--- a/src/Command/ExportCommand.php
+++ b/src/Command/ExportCommand.php
@@ -7,7 +7,7 @@
 
 namespace Drupal\webprofiler\Command;
 
-use Drupal\AppConsole\Command\ContainerAwareCommand;
+use Drupal\Console\Command\ContainerAwareCommand;
 use Drupal\Core\Archiver\ArchiveTar;
 use Drupal\webprofiler\Profiler\Profiler;
 use Symfony\Component\Console\Helper\ProgressBar;

--- a/src/Command/ListCommand.php
+++ b/src/Command/ListCommand.php
@@ -7,7 +7,7 @@
 
 namespace Drupal\webprofiler\Command;
 
-use Drupal\AppConsole\Command\ContainerAwareCommand;
+use Drupal\Console\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;


### PR DESCRIPTION
* Fix namespace on BenchmarkCommand
* Fix namespace on ExportCommand
* Fix namespace on ListCommand

NOTE: Namespaces changes are required to sync with Drupal Console changes on release v0.9.0
https://github.com/hechoendrupal/DrupalConsole/releases/tag/0.9.0